### PR TITLE
Fix compiler warning about __always_inline

### DIFF
--- a/usb/inc/usb_cdcacm.h
+++ b/usb/inc/usb_cdcacm.h
@@ -169,7 +169,7 @@ int usb_cdcacm_get_n_data_bits(void); /* bDataBits */
 
 void usb_cdcacm_set_hooks(unsigned hook_flags, void (*hook)(unsigned, void*));
 
-static inline __always_inline void usb_cdcacm_remove_hooks(unsigned hook_flags) {
+static inline void usb_cdcacm_remove_hooks(unsigned hook_flags) {
     usb_cdcacm_set_hooks(hook_flags, 0);
 }
 


### PR DESCRIPTION
This should fix compiler warning/error:

![bildschirmfoto vom 2019-02-07 00-17-11](https://user-images.githubusercontent.com/7112907/52383431-a3430a80-2a79-11e9-8f09-710ddbc626b4.png)

Patch:

![bildschirmfoto vom 2019-02-07 00-57-50](https://user-images.githubusercontent.com/7112907/52383425-9aeacf80-2a79-11e9-8bcd-58e561539f1e.png)
